### PR TITLE
Generate phoveaMetaData.json from workspace/product package.json (and not the application)

### DIFF
--- a/buildInfo.js
+++ b/buildInfo.js
@@ -149,7 +149,7 @@ function metaData(pkg) {
     name: pkg.name,
     displayName: pkg.displayName,
     version: pkg.version,
-    repository: pkg.repository.url,
+    repository: (pkg.repository) ? pkg.repository.url : null,
     homepage: pkg.homepage,
     description: pkg.description,
     screenshot: resolveScreenshot()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -169,12 +169,12 @@ let metaDataFile;
 if(isWorkspaceContext) {
   const workspacePkg = require('../package.json'); // workspace or product
   workspacePkg.version = workspacePkg.version.replace('SNAPSHOT', buildId);
-  console.log(`generate phoveaMetaData.json from '${workspacePkg.name}' package.json`);
+  console.log(`generate phoveaMetaData.json from '${workspacePkg.name}' package.json with version ${workspacePkg.version}`);
   metaDataFile = workspacePkg;
   // Note: The screenshot in the phoveaMetaData.json is still taken from `./media/screenshot.png` of the current plugin/application,
   // because it is resolved in `buildInfo.metaDataTmpFile()` from the current directory and independent of the provided package.json
 } else {
-  console.log(`generate phoveaMetaData.json from '${pkg.name}' package.json`);
+  console.log(`generate phoveaMetaData.json from '${pkg.name}' package.json with version ${pkg.version}`);
   metaDataFile = pkg;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,7 +164,21 @@ function testPhoveaModules(modules) {
 // use workspace registry file if available
 const isWorkspaceContext = fs.existsSync(resolve(__dirname, '..', 'phovea_registry.js'));
 const registryFile = isWorkspaceContext ? '../phovea_registry.js' : './phovea_registry.js';
-const actMetaData = `file-loader?name=phoveaMetaData.json!${buildInfo.metaDataTmpFile(pkg)}`;
+
+let metaDataFile;
+if(isWorkspaceContext) {
+  const workspacePkg = require('../package.json'); // workspace or product
+  workspacePkg.version = workspacePkg.version.replace('SNAPSHOT', buildId);
+  console.log(`generate phoveaMetaData.json from '${workspacePkg.name}' package.json`);
+  metaDataFile = workspacePkg;
+  // Note: The screenshot in the phoveaMetaData.json is still taken from `./media/screenshot.png` of the current plugin/application,
+  // because it is resolved in `buildInfo.metaDataTmpFile()` from the current directory and independent of the provided package.json
+} else {
+  console.log(`generate phoveaMetaData.json from '${pkg.name}' package.json`);
+  metaDataFile = pkg;
+}
+
+const actMetaData = `file-loader?name=phoveaMetaData.json!${buildInfo.metaDataTmpFile(metaDataFile)}`;
 const actBuildInfoFile = `file-loader?name=buildInfo.json!${buildInfo.tmpFile()}`;
 
 /**


### PR DESCRIPTION
See phovea/generator-phovea#189

### Summary

Uses the _package.json_ of the workspace/product to generate the _phoveaMetaData.json_. That solves the problem that the version number of the product (and not of the application) is shown in the _About_ dialog.