### PR TITLE
Show Ordino Public migration message for persistent sessions in start menu

### DIFF
--- a/src/WelcomeView.ts
+++ b/src/WelcomeView.ts
@@ -11,14 +11,31 @@ export default class WelcomeView implements IWelcomeView {
   build() {
     this.parent.insertAdjacentHTML('afterbegin', WelcomeViewTemplate);
 
-    // add message to ordino public - temporary change
-    const template = `
-    <div class="alert alert-warning" style="max-width: fit-content;" role="alert">
-      <strong>Please note:</strong> We have upgraded Ordino to the hg38 genome build, which might change the result of some old sessions.
-      If you experience some issues please open previous sessions in the <a href="https://ordino-hg19.caleydoapp.org">Ordino with hg19</a>.
-    </div>`;
+    const dataToggleElement = document.getElementById('tdpSessionPersistentDataToggle');
+    const parentNode = document.querySelector('.tdpSessionPersistentData .body');
+    dataToggleElement.addEventListener('click', (evt) => {
+      this.createMigrationMessage(parentNode);
+    });
+  }
 
-    const persitedSessionsNode = document.querySelector('.tdpSessionPersistentData .item');
-    persitedSessionsNode.insertAdjacentHTML('afterbegin', template);
+/**
+ * Create migration message to add to the persisstent sessions section. Temporary feature will be removed eventually.
+ */
+  createMigrationMessage(parentNode: Element) {
+    let warningMessage = parentNode.querySelector('div.alert-warning');
+    if (warningMessage) {
+      return;
+    }
+
+    const textNode = parentNode.childNodes[1];
+    warningMessage = document.createElement('div');
+    warningMessage.className = 'alert alert-warning';
+    warningMessage.setAttribute('role', 'alert');
+    (warningMessage as HTMLDivElement).style.maxWidth = 'fit-content';
+    warningMessage.innerHTML = `
+      <strong>Please note:</strong> We have upgraded Ordino to the hg38 genome build, which might change the result of some old sessions.
+      If you experience some issues please open previous sessions in the <a href="https://ordino-hg19.caleydoapp.org">Ordino with hg19</a>.`;
+
+    parentNode.insertBefore(warningMessage, textNode);
   }
 }

--- a/src/WelcomeView.ts
+++ b/src/WelcomeView.ts
@@ -10,5 +10,15 @@ export default class WelcomeView implements IWelcomeView {
 
   build() {
     this.parent.insertAdjacentHTML('afterbegin', WelcomeViewTemplate);
+
+    // add message to ordino public - temporary change
+    const template = `
+    <div class="alert alert-warning" style="max-width: fit-content;" role="alert">
+      <strong>Please note:</strong> We have upgraded Ordino to the hg38 genome build, which might change the result of some old sessions.
+      If you experience some issues please open previous sessions in the <a href="https://ordino-hg19.caleydoapp.org">Ordino with hg19</a>.
+    </div>`;
+
+    const persitedSessionsNode = document.querySelector('.tdpSessionPersistentData .item');
+    persitedSessionsNode.insertAdjacentHTML('afterbegin', template);
   }
 }

--- a/src/WelcomeView.ts
+++ b/src/WelcomeView.ts
@@ -27,7 +27,7 @@ export default class WelcomeView implements IWelcomeView {
       return;
     }
 
-    const textNode = parentNode.childNodes[1];
+    const sessionsTable = parentNode.childNodes[1];
     warningMessage = document.createElement('div');
     warningMessage.className = 'alert alert-warning';
     warningMessage.setAttribute('role', 'alert');
@@ -36,6 +36,6 @@ export default class WelcomeView implements IWelcomeView {
       <strong>Please note:</strong> We have upgraded Ordino to the hg38 genome build, which might change the result of some old sessions.
       If you experience some issues please open previous sessions in the <a href="https://ordino-hg19.caleydoapp.org">Ordino with hg19</a>.`;
 
-    parentNode.insertBefore(warningMessage, textNode);
+    parentNode.insertBefore(warningMessage, sessionsTable);
   }
 }


### PR DESCRIPTION
Closes Caleydo/ordino_public#62

### Summary 
I am appending the migration message in the` onClick` handler because the target node does not yet exist when the `ordino_public` welcome view is being built.


### Sreenshot

![grafik](https://user-images.githubusercontent.com/51322092/86912008-82725f00-c11c-11ea-944d-5a8ad74a4ee8.png)

