### PR TITLE
Show Ordino migration message as popup and on welcome page

### DIFF
--- a/src/WelcomeView.ts
+++ b/src/WelcomeView.ts
@@ -1,8 +1,12 @@
 import {IWelcomeView} from 'ordino/src/WelcomeView';
 
 import WelcomeViewTemplate from 'html-loader!./welcome_view.html';
+import {generateDialog} from 'phovea_ui/src/dialogs';
+import * as session from 'phovea_core/src/session';
 
 export default class WelcomeView implements IWelcomeView {
+
+  private static DISMISS_POPUP_SESSION_KEY = 'OrdinoDismissMigrationPopup';
 
   constructor(private parent: HTMLElement) {
     //
@@ -16,12 +20,14 @@ export default class WelcomeView implements IWelcomeView {
     dataToggleElement.addEventListener('click', (evt) => {
       this.createMigrationMessage(parentNode);
     });
+
+    this.showMigrationPopup();
   }
 
-/**
- * Create migration message to add to the persisstent sessions section. Temporary feature will be removed eventually.
- */
-  createMigrationMessage(parentNode: Element) {
+  /**
+   * Create migration message to add to the persisstent sessions section. Temporary feature will be removed eventually.
+   */
+  private createMigrationMessage(parentNode: Element) {
     let warningMessage = parentNode.querySelector('div.alert-warning');
     if (warningMessage) {
       return;
@@ -37,5 +43,43 @@ export default class WelcomeView implements IWelcomeView {
       If you experience some issues please open previous sessions in the <a href="https://ordino-hg19.caleydoapp.org">Ordino with hg19</a>.`;
 
     parentNode.insertBefore(warningMessage, sessionsTable);
+  }
+
+  private showMigrationPopup() {
+    // dismissed flag is active == do not show the popup
+    if(session.has(WelcomeView.DISMISS_POPUP_SESSION_KEY) && session.retrieve(WelcomeView.DISMISS_POPUP_SESSION_KEY) === true) {
+      return;
+    }
+
+    const dialog = generateDialog('Ordino just got better!');
+
+    dialog.body.innerHTML = `
+    We have updated the data in Ordino from genome build hg19 to build hg38.
+    Additionally we also extended the available data.
+    As a consequence of these changes, analysis results can differ slightly compared to the previous Ordino version.
+    If necessary, you can still access the original hg19 instance here: <a href="https://ordino-hg19.caleydoapp.org">ordino-hg19.caleydoapp.org</a>`;
+
+    dialog.footer.innerHTML = `
+      <div class="row">
+        <div class="col-md-6" style="text-align: left;">
+          <label><input type="checkbox" name="dismiss"> Do not show this again</label>
+        </div>
+        <div class="col-md-6">
+          <button type="button" class="btn btn-default btn-primary submit-dialog">Close</button>
+        </div>
+      </div>
+    `;
+
+    dialog.footer.querySelector('button').onclick = () => {
+      dialog.hide();
+    };
+
+    const dismissCheckbox = dialog.footer.querySelector('input');
+
+    dialog.onHide(() => {
+      session.store(WelcomeView.DISMISS_POPUP_SESSION_KEY, dismissCheckbox.checked);
+    });
+
+    dialog.show();
   }
 }

--- a/src/phovea.ts
+++ b/src/phovea.ts
@@ -2,6 +2,7 @@ import {IRegistry, asResource} from 'phovea_core/src/plugin';
 import parseRange from 'phovea_core/src/range/parser';
 import ActionNode from 'phovea_core/src/provenance/ActionNode';
 import {ILocaleEPDesc, EP_PHOVEA_CORE_LOCALE} from 'phovea_core/src/extensions';
+import {EP_PHOVEA_CLUE_PROVENANCE_GRAPH} from 'phovea_clue/src/extensions';
 
 export default function (registry: IRegistry) {
   //registry.push('extension-type', 'extension-id', function() { return import('./extension_impl'); }, {});
@@ -16,6 +17,9 @@ export default function (registry: IRegistry) {
     ns: 'tdp',
   });
 
+  registry.push(EP_PHOVEA_CLUE_PROVENANCE_GRAPH, 'dismissMigrationPopup', () => System.import('./WelcomeView'), {
+    factory: 'dismissMigrationPopup'
+  });
   // generator-phovea:end
 
 }

--- a/src/welcome_view.html
+++ b/src/welcome_view.html
@@ -15,6 +15,13 @@
         <a href="https://doi.org/10.1038/ng.3984" rel="noopener" target="_blank">Meyers et al. (Nat. Genet. 2017)</a>.
       </p>
     </div>
+    <div class="text-center col-xs-4 col-xs-offset-4 alert alert-warning text-center" role="alert">
+      <strong>Please note</strong>: We have updated the data in Ordino from genome build hg19 to build hg38.
+      Additionally we also extended the available data.<br> As a consequence of these changes,
+      analysis results can differ slightly compared to the previous Ordino version.<br>
+      If necessary, you can still access the original hg19 instance here:
+      <a href="https://ordino-hg19.caleydoapp.org">ordino-hg19.caleydoapp.org</a>.
+    </div>
   </div>
   <div class="row wizard">
     <div class="col-xs-4 wizard-step">


### PR DESCRIPTION
Closes #63 

### Summary

* Show migration message on welcome page
* Open migration popup on first open
* Allow to dismiss the popup (by storing a flag in the session storage)
* Even if the user wants to see the popup again, it should not show up if the user clicks on an entry point, a session or comes from an old session

![ordino-migration-popup](https://user-images.githubusercontent.com/5851088/87427384-fa3efe80-c5e0-11ea-930e-50297a8ff4c1.gif)
