### PR TITLE
Provide meta tags for SEO and social media

### DIFF
--- a/dist/app.template.ejs
+++ b/dist/app.template.ejs
@@ -1,10 +1,35 @@
 <!doctype html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ordino</title>
-    <meta name="description" content="">
-    <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+  <title>Ordino</title>
+  <meta name="description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="keywords" content="Ordino, visualization, ranking, genes, cell lines, tissue samples">
+  <meta name="author" content="Johannes Kepler University Linz, Boehringer Ingelheim, datavisyn">
+  <meta name="application-name" content="Ordino">
+  <!--<meta name="theme-color" content="#006192">-->
+  <meta name="robots" content="index,nofollow">
+  <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@datavisyn">
+  <meta name="twitter:title" value="Ordino" />
+  <meta name="twitter:description" value="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta name="twitter:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta name="twitter:url" value="https://ordino.caleydoapp.org" />
+
+  <!-- Other Social Media -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Ordino"/>
+  <meta property="og:site_name" content="Ordino"/>
+  <meta property="og:description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta property="og:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta property="og:url" content="https://ordino.caleydoapp.org" />
 </head>
 <body>
   <%=require('tdp_core/dist/template/_body.html')%>

--- a/dist/welcome.template.ejs
+++ b/dist/welcome.template.ejs
@@ -1,13 +1,35 @@
 <!doctype html>
 <html>
 <head>
-    <title>Ordino</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width">
-    <link href="<%=require('./assets/favicon.png')%>" rel="icon">
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+  <title>Ordino</title>
+  <meta name="description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="keywords" content="Ordino, visualization, ranking, genes, cell lines, tissue samples">
+  <meta name="author" content="Johannes Kepler University Linz, Boehringer Ingelheim, datavisyn">
+  <meta name="application-name" content="Ordino">
+  <!--<meta name="theme-color" content="#006192">-->
+  <meta name="robots" content="index,nofollow">
+  <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@datavisyn">
+  <meta name="twitter:title" value="Ordino" />
+  <meta name="twitter:description" value="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta name="twitter:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta name="twitter:url" value="https://ordino.caleydoapp.org" />
+
+  <!-- Other Social Media -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Ordino"/>
+  <meta property="og:site_name" content="Ordino"/>
+  <meta property="og:description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta property="og:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta property="og:url" content="https://ordino.caleydoapp.org" />
 </head>
 <body>
   <script>

--- a/src/app.template.ejs
+++ b/src/app.template.ejs
@@ -1,10 +1,35 @@
 <!doctype html>
 <html>
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ordino</title>
-    <meta name="description" content="">
-    <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+  <title>Ordino</title>
+  <meta name="description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="keywords" content="Ordino, visualization, ranking, genes, cell lines, tissue samples">
+  <meta name="author" content="Johannes Kepler University Linz, Boehringer Ingelheim, datavisyn">
+  <meta name="application-name" content="Ordino">
+  <!--<meta name="theme-color" content="#006192">-->
+  <meta name="robots" content="index,nofollow">
+  <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@datavisyn">
+  <meta name="twitter:title" value="Ordino" />
+  <meta name="twitter:description" value="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta name="twitter:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta name="twitter:url" value="https://ordino.caleydoapp.org" />
+
+  <!-- Other Social Media -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Ordino"/>
+  <meta property="og:site_name" content="Ordino"/>
+  <meta property="og:description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta property="og:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta property="og:url" content="https://ordino.caleydoapp.org" />
 </head>
 <body>
   <%=require('tdp_core/dist/template/_body.html')%>

--- a/src/welcome.template.ejs
+++ b/src/welcome.template.ejs
@@ -1,13 +1,35 @@
 <!doctype html>
 <html>
 <head>
-    <title>Ordino</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width">
-    <link href="<%=require('./assets/favicon.png')%>" rel="icon">
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+  <title>Ordino</title>
+  <meta name="description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="keywords" content="Ordino, visualization, ranking, genes, cell lines, tissue samples">
+  <meta name="author" content="Johannes Kepler University Linz, Boehringer Ingelheim, datavisyn">
+  <meta name="application-name" content="Ordino">
+  <!--<meta name="theme-color" content="#006192">-->
+  <meta name="robots" content="index,nofollow">
+  <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@datavisyn">
+  <meta name="twitter:title" value="Ordino" />
+  <meta name="twitter:description" value="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta name="twitter:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta name="twitter:url" value="https://ordino.caleydoapp.org" />
+
+  <!-- Other Social Media -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Ordino"/>
+  <meta property="og:site_name" content="Ordino"/>
+  <meta property="og:description" content="Ordino is a browser-based visual data analysis solution to flexibly rank, filter, and explore genes, cell lines, and tissue samples based on a rich set of experimental and metadata." />
+  <meta property="og:image" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:secure_url" content="https://raw.githubusercontent.com/Caleydo/ordino_public/master/media/screenshot.full.png" />
+  <meta property="og:image:alt" content="Screenshot of an analysis session in Ordino.">
+  <meta property="og:url" content="https://ordino.caleydoapp.org" />
 </head>
 <body>
   <script>


### PR DESCRIPTION
Closes Caleydo/tdp_bi_bioinfodb#1312
I made a screenshot suggestion: https://github.com/Caleydo/ordino_public/pull/128
Changed the default color mapping of some columns

### Summary
* Added the meta tags as described Caleydo/tdp_bi_bioinfodb#1312

These tags

```html
<meta charset='utf-8'>
<meta name="viewport" content="width=device-width">
 <link rel="icon" type="image/svg+xml" href="<%=require('./assets/favicon.svg')%>"/>
<script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
```

are covered in 
```html
  <link rel="icon" href="<%=require('tdp_core/dist/assets/favicon.png')%>"><%=require('tdp_core/dist/template/_head.html')%>
```

Regarding the icon, we were using the `favicon.png` before and i do not think we have an SVG one, or am I wrong?

I removed the font import since it was not there before and i think we import that in scss already

`<link href="https://fonts.googleapis.com/css?family=Yantramanav:700,500,400" rel="stylesheet" type="text/css"/>`

Let me know if that was a mistake.